### PR TITLE
Dont hang on qsub call, since it expects input

### DIFF
--- a/SUSYBSMAnalysis/HSCP/python/LaunchOnCondor.py
+++ b/SUSYBSMAnalysis/HSCP/python/LaunchOnCondor.py
@@ -383,8 +383,8 @@ def SendCluster_Create(FarmDirectory, JobName):
 
 	#determine what is the submission system available, or use condor
         if(subTool==''):
-  	   if(  commands.getstatusoutput("bjobs")[1].find("command not found")<0): subTool = 'bsub'
-           elif(commands.getstatusoutput("qsub")[1].find("command not found")<0): subTool = 'qsub'
+  	   if(  not commands.getstatusoutput("which bjobs")[1].startswith("which:")): subTool = 'bsub'
+           elif( not commands.getstatusoutput("which qsub")[1].startswith("which:")): subTool = 'qsub'
            else:                                                                   subTool = 'condor'
         if(Jobs_Queue.find('crab')>=0):                                            subTool = 'crab'
 


### PR DESCRIPTION
On our site qsub expects some input when called without any arguments. This locks the submission and Launch.py hangs. This PR fixes this.
